### PR TITLE
[CP-197][mempool] Add mutex to all PriorityNonceMempool calls to allow parallel CheckTx

### DIFF
--- a/block/base/priority_nonce.go
+++ b/block/base/priority_nonce.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/huandu/skiplist"
 
@@ -77,6 +78,7 @@ type (
 		scores          map[txMeta[C]]txMeta[C]
 		cfg             PriorityNonceMempoolConfig[C]
 		signerExtractor signer_extraction.Adapter
+		mux             sync.RWMutex
 	}
 
 	// PriorityNonceIterator defines an iterator that is used for mempool iteration
@@ -199,6 +201,9 @@ func DefaultPriorityMempool(extractor signer_extraction.DefaultAdapter) *Priorit
 // i.e. the next valid transaction for the sender. If no such transaction exists,
 // nil will be returned.
 func (mp *PriorityNonceMempool[C]) NextSenderTx(sender string) sdk.Tx {
+	mp.mux.RLock()
+	defer mp.mux.RUnlock()
+
 	senderIndex, ok := mp.senderIndices[sender]
 	if !ok {
 		return nil
@@ -218,6 +223,9 @@ func (mp *PriorityNonceMempool[C]) NextSenderTx(sender string) sdk.Tx {
 // Inserting a duplicate tx with a different priority overwrites the existing tx,
 // changing the total order of the mempool.
 func (mp *PriorityNonceMempool[C]) Insert(ctx context.Context, tx sdk.Tx) error {
+	mp.mux.Lock()
+	defer mp.mux.Unlock()
+
 	if mp.cfg.MaxTx > 0 && mp.CountTx() >= mp.cfg.MaxTx {
 		return sdkmempool.ErrMempoolTxMaxCapacity
 	} else if mp.cfg.MaxTx < 0 {
@@ -289,6 +297,9 @@ func (mp *PriorityNonceMempool[C]) Insert(ctx context.Context, tx sdk.Tx) error 
 }
 
 func (i *PriorityNonceIterator[C]) iteratePriority() sdkmempool.Iterator {
+	i.mempool.mux.RLock()
+	defer i.mempool.mux.RUnlock()
+
 	// beginning of priority iteration
 	if i.priorityNode == nil {
 		i.priorityNode = i.mempool.priorityIndex.Front()
@@ -314,6 +325,9 @@ func (i *PriorityNonceIterator[C]) iteratePriority() sdkmempool.Iterator {
 }
 
 func (i *PriorityNonceIterator[C]) Next() sdkmempool.Iterator {
+	i.mempool.mux.RLock()
+	defer i.mempool.mux.RUnlock()
+
 	if i.priorityNode == nil {
 		return nil
 	}
@@ -364,7 +378,7 @@ func (i *PriorityNonceIterator[C]) Tx() sdk.Tx {
 // The maxBytes parameter defines the maximum number of bytes of transactions to
 // return.
 func (mp *PriorityNonceMempool[C]) Select(_ context.Context, _ [][]byte) sdkmempool.Iterator {
-	if mp.priorityIndex.Len() == 0 {
+	if mp.CountTx() == 0 {
 		return nil
 	}
 
@@ -385,6 +399,9 @@ type reorderKey[C comparable] struct {
 }
 
 func (mp *PriorityNonceMempool[C]) reorderPriorityTies() {
+	mp.mux.Lock()
+	defer mp.mux.Unlock()
+
 	node := mp.priorityIndex.Front()
 
 	var reordering []reorderKey[C]
@@ -432,12 +449,18 @@ func senderWeight[C comparable](txPriority TxPriority[C], senderCursor *skiplist
 
 // CountTx returns the number of transactions in the mempool.
 func (mp *PriorityNonceMempool[C]) CountTx() int {
+	mp.mux.RLock()
+	defer mp.mux.RUnlock()
+
 	return mp.priorityIndex.Len()
 }
 
 // Remove removes a transaction from the mempool in O(log n) time, returning an
 // error if unsuccessful.
 func (mp *PriorityNonceMempool[C]) Remove(tx sdk.Tx) error {
+	mp.mux.Lock()
+	defer mp.mux.Unlock()
+
 	signers, err := mp.signerExtractor.GetSigners(tx)
 	if err != nil {
 		return err
@@ -472,6 +495,9 @@ func (mp *PriorityNonceMempool[C]) Remove(tx sdk.Tx) error {
 
 // Contains returns true if the transaction is in the mempool.
 func (mp *PriorityNonceMempool[C]) Contains(tx sdk.Tx) bool {
+	mp.mux.RLock()
+	defer mp.mux.RUnlock()
+
 	signers, err := mp.signerExtractor.GetSigners(tx)
 	if err != nil {
 		return false
@@ -490,6 +516,10 @@ func (mp *PriorityNonceMempool[C]) Contains(tx sdk.Tx) bool {
 
 func IsEmpty[C comparable](mempool sdkmempool.Mempool) error {
 	mp := mempool.(*PriorityNonceMempool[C])
+
+	mp.mux.RLock()
+	defer mp.mux.RUnlock()
+
 	if mp.priorityIndex.Len() != 0 {
 		return fmt.Errorf("priorityIndex not empty")
 	}

--- a/block/base/priority_nonce.go
+++ b/block/base/priority_nonce.go
@@ -226,7 +226,7 @@ func (mp *PriorityNonceMempool[C]) Insert(ctx context.Context, tx sdk.Tx) error 
 	mp.mux.Lock()
 	defer mp.mux.Unlock()
 
-	if mp.cfg.MaxTx > 0 && mp.CountTx() >= mp.cfg.MaxTx {
+	if mp.cfg.MaxTx > 0 && mp.priorityIndex.Len() >= mp.cfg.MaxTx {
 		return sdkmempool.ErrMempoolTxMaxCapacity
 	} else if mp.cfg.MaxTx < 0 {
 		return nil
@@ -378,9 +378,12 @@ func (i *PriorityNonceIterator[C]) Tx() sdk.Tx {
 // The maxBytes parameter defines the maximum number of bytes of transactions to
 // return.
 func (mp *PriorityNonceMempool[C]) Select(_ context.Context, _ [][]byte) sdkmempool.Iterator {
-	if mp.CountTx() == 0 {
+	mp.mux.RLock()
+	if mp.priorityIndex.Len() == 0 {
+		mp.mux.RUnlock()
 		return nil
 	}
+	mp.mux.RUnlock()
 
 	mp.reorderPriorityTies()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced concurrency control to ensure more reliable and stable performance during simultaneous operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->