### PR TITLE
[C-696] fix(laned_mempool): support tx fallthrough when lane is full

### DIFF
--- a/block/mempool.go
+++ b/block/mempool.go
@@ -103,7 +103,7 @@ laneMatching:
 			signersData, err := lane.SignerExtractor().GetSigners(tx)
 			if err != nil {
 				m.logger.Error("failed to extract signers upon insertion for tx", "tx", tx, "err", err)
-				return nil
+				return fmt.Errorf("failed to extract signers upon insertion for tx: %w", err)
 			}
 			for _, signerData := range signersData {
 				if m.txIndex.DoesExistInLowerPriorityLane(signerData.Signer.String(), index) {
@@ -170,7 +170,7 @@ func (m *LanedMempool) Remove(tx sdk.Tx) (err error) {
 			signersData, err := lane.SignerExtractor().GetSigners(tx)
 			if err != nil {
 				m.logger.Error("failed to extract signers upon removal for tx", "tx", tx, "err", err)
-				return nil
+				return fmt.Errorf("failed to extract signers upon removal for tx: %w", err)
 			}
 
 			sig := signersData[0]

--- a/block/mempool.go
+++ b/block/mempool.go
@@ -105,6 +105,9 @@ laneMatching:
 				m.logger.Error("failed to extract signers upon insertion for tx", "tx", tx, "err", err)
 				return fmt.Errorf("failed to extract signers upon insertion for tx: %w", err)
 			}
+			if len(signersData) == 0 {
+				return fmt.Errorf("no signers found for tx during insertion")
+			}
 			for _, signerData := range signersData {
 				if m.txIndex.DoesExistInLowerPriorityLane(signerData.Signer.String(), index) {
 					// If the transaction exists in a lower priority lane, we let
@@ -171,6 +174,9 @@ func (m *LanedMempool) Remove(tx sdk.Tx) (err error) {
 			if err != nil {
 				m.logger.Error("failed to extract signers upon removal for tx", "tx", tx, "err", err)
 				return fmt.Errorf("failed to extract signers upon removal for tx: %w", err)
+			}
+			if len(signersData) == 0 {
+				return fmt.Errorf("no signers found for tx during removal")
 			}
 
 			sig := signersData[0]

--- a/block/mempool.go
+++ b/block/mempool.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/log"
@@ -106,8 +107,8 @@ laneMatching:
 			}
 			for _, signerData := range signersData {
 				if m.txIndex.DoesExistInLowerPriorityLane(signerData.Signer.String(), index) {
-
-					// If the transaction exists in a lower priority lane, do not insert it.
+					// If the transaction exists in a lower priority lane, we let
+					// it trickle down until it reaches that lane.
 					// This is because it could cause account sequence mismatches.
 					continue laneMatching
 				}
@@ -116,6 +117,11 @@ laneMatching:
 
 			err = lane.Insert(ctx, tx)
 			if err != nil {
+				if errors.Is(err, sdkmempool.ErrMempoolTxMaxCapacity) {
+					// if the lane is at capacity, we let it trickle down to the
+					// next lane.
+					continue laneMatching
+				}
 				return err
 			}
 

--- a/block/mempool_coverage_test.go
+++ b/block/mempool_coverage_test.go
@@ -1,0 +1,151 @@
+package block_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
+
+	signerextraction "github.com/skip-mev/block-sdk/v2/adapters/signer_extraction_adapter"
+	"github.com/skip-mev/block-sdk/v2/block"
+)
+
+type staticSignerAdapter struct {
+	signers []signerextraction.SignerData
+}
+
+func (s staticSignerAdapter) GetSigners(sdk.Tx) ([]signerextraction.SignerData, error) {
+	return s.signers, nil
+}
+
+func TestLanedMempoolInsertTricklesOnCapacity(t *testing.T) {
+	signer := signerextraction.SignerData{Signer: sdk.AccAddress("addr1"), Sequence: 1}
+	adapter := staticSignerAdapter{signers: []signerextraction.SignerData{signer}}
+
+	priorityLane := &testLane{
+		name:            "priority",
+		match:           true,
+		insertErr:       sdkmempool.ErrMempoolTxMaxCapacity,
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyMustNewDecFromStr("0.5"),
+	}
+	defaultLane := &testLane{
+		name:            "default",
+		match:           true,
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyZeroDec(),
+	}
+
+	mempool, err := block.NewLanedMempool(log.NewNopLogger(), []block.Lane{priorityLane, defaultLane})
+	require.NoError(t, err)
+
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
+	require.NoError(t, err)
+	require.Equal(t, 0, priorityLane.CountTx())
+	require.Equal(t, 1, defaultLane.CountTx())
+}
+
+func TestLanedMempoolInsertSkipsHigherLaneWhenLowerExists(t *testing.T) {
+	signer := signerextraction.SignerData{Signer: sdk.AccAddress("addr1"), Sequence: 1}
+	adapter := staticSignerAdapter{signers: []signerextraction.SignerData{signer}}
+
+	priorityLane := &testLane{
+		name:            "priority",
+		match:           false,
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyMustNewDecFromStr("0.5"),
+	}
+	defaultLane := &testLane{
+		name:            "default",
+		match:           true,
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyZeroDec(),
+	}
+
+	mempool, err := block.NewLanedMempool(log.NewNopLogger(), []block.Lane{priorityLane, defaultLane})
+	require.NoError(t, err)
+
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
+	require.NoError(t, err)
+	require.Equal(t, 1, defaultLane.CountTx())
+
+	priorityLane.match = true
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
+	require.NoError(t, err)
+	require.Equal(t, 0, priorityLane.CountTx())
+	require.Equal(t, 2, defaultLane.CountTx())
+}
+
+func TestLanedMempoolInsertPropagatesLaneError(t *testing.T) {
+	signer := signerextraction.SignerData{Signer: sdk.AccAddress("addr1"), Sequence: 1}
+	adapter := staticSignerAdapter{signers: []signerextraction.SignerData{signer}}
+
+	priorityLane := &testLane{
+		name:            "priority",
+		match:           true,
+		insertErr:       fmt.Errorf("insert failed"),
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyOneDec(),
+	}
+
+	mempool, err := block.NewLanedMempool(log.NewNopLogger(), []block.Lane{priorityLane})
+	require.NoError(t, err)
+
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insert failed")
+}
+
+func TestLanedMempoolRemovePropagatesLaneError(t *testing.T) {
+	signer := signerextraction.SignerData{Signer: sdk.AccAddress("addr1"), Sequence: 1}
+	adapter := staticSignerAdapter{signers: []signerextraction.SignerData{signer}}
+
+	priorityLane := &testLane{
+		name:            "priority",
+		contains:        true,
+		removeErr:       fmt.Errorf("remove failed"),
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyOneDec(),
+	}
+
+	mempool, err := block.NewLanedMempool(log.NewNopLogger(), []block.Lane{priorityLane})
+	require.NoError(t, err)
+
+	err = mempool.Remove(EmptyTx{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remove failed")
+}
+
+func TestLanedMempoolRemoveSuccess(t *testing.T) {
+	signer := signerextraction.SignerData{Signer: sdk.AccAddress("addr1"), Sequence: 1}
+	adapter := staticSignerAdapter{signers: []signerextraction.SignerData{signer}}
+
+	priorityLane := &testLane{
+		name:            "priority",
+		match:           false,
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyMustNewDecFromStr("0.5"),
+	}
+	defaultLane := &testLane{
+		name:            "default",
+		match:           true,
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyZeroDec(),
+	}
+
+	mempool, err := block.NewLanedMempool(log.NewNopLogger(), []block.Lane{priorityLane, defaultLane})
+	require.NoError(t, err)
+
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
+	require.NoError(t, err)
+	require.Equal(t, 1, defaultLane.CountTx())
+
+	err = mempool.Remove(EmptyTx{})
+	require.NoError(t, err)
+	require.Equal(t, 0, defaultLane.CountTx())
+}

--- a/block/mempool_error_test.go
+++ b/block/mempool_error_test.go
@@ -124,6 +124,7 @@ func TestLanedMempoolInsertReturnsSignerError(t *testing.T) {
 		name:            "test",
 		match:           true,
 		signerExtractor: errorSignerAdapter{},
+		maxBlockSpace:   math.LegacyZeroDec(),
 	}
 
 	mempool, err := block.NewLanedMempool(
@@ -132,7 +133,7 @@ func TestLanedMempoolInsertReturnsSignerError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = mempool.Insert(context.Background(), EmptyTx{})
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to extract signers upon insertion")
 }
@@ -142,6 +143,7 @@ func TestLanedMempoolRemoveReturnsSignerError(t *testing.T) {
 		name:            "test",
 		contains:        true,
 		signerExtractor: errorSignerAdapter{},
+		maxBlockSpace:   math.LegacyZeroDec(),
 	}
 
 	mempool, err := block.NewLanedMempool(
@@ -160,6 +162,7 @@ func TestLanedMempoolInsertRejectsEmptySigners(t *testing.T) {
 		name:            "test",
 		match:           true,
 		signerExtractor: emptySignerAdapter{},
+		maxBlockSpace:   math.LegacyZeroDec(),
 	}
 
 	mempool, err := block.NewLanedMempool(
@@ -168,7 +171,7 @@ func TestLanedMempoolInsertRejectsEmptySigners(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = mempool.Insert(context.Background(), EmptyTx{})
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no signers found for tx during insertion")
 }
@@ -178,6 +181,7 @@ func TestLanedMempoolRemoveRejectsEmptySigners(t *testing.T) {
 		name:            "test",
 		contains:        true,
 		signerExtractor: emptySignerAdapter{},
+		maxBlockSpace:   math.LegacyZeroDec(),
 	}
 
 	mempool, err := block.NewLanedMempool(

--- a/block/mempool_error_test.go
+++ b/block/mempool_error_test.go
@@ -1,0 +1,150 @@
+package block_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
+
+	signerextraction "github.com/skip-mev/block-sdk/v2/adapters/signer_extraction_adapter"
+	"github.com/skip-mev/block-sdk/v2/block"
+	"github.com/skip-mev/block-sdk/v2/block/proposals"
+	"github.com/skip-mev/block-sdk/v2/block/utils"
+)
+
+type errorSignerAdapter struct{}
+
+func (errorSignerAdapter) GetSigners(sdk.Tx) ([]signerextraction.SignerData, error) {
+	return nil, fmt.Errorf("boom")
+}
+
+type testLane struct {
+	name            string
+	match           bool
+	contains        bool
+	insertErr       error
+	removeErr       error
+	maxBlockSpace   math.LegacyDec
+	signerExtractor signerextraction.Adapter
+	count           int
+}
+
+func (t *testLane) PrepareLane(sdk.Context, proposals.Proposal, block.PrepareLanesHandler) (proposals.Proposal, error) {
+	return proposals.Proposal{}, nil
+}
+
+func (t *testLane) ProcessLane(sdk.Context, proposals.Proposal, []sdk.Tx, block.ProcessLanesHandler) (proposals.Proposal, error) {
+	return proposals.Proposal{}, nil
+}
+
+func (t *testLane) GetMaxBlockSpace() math.LegacyDec {
+	return t.maxBlockSpace
+}
+
+func (t *testLane) SetMaxBlockSpace(space math.LegacyDec) {
+	t.maxBlockSpace = space
+}
+
+func (t *testLane) Logger() log.Logger {
+	return log.NewNopLogger()
+}
+
+func (t *testLane) Name() string {
+	return t.name
+}
+
+func (t *testLane) GetTxInfo(sdk.Context, sdk.Tx) (utils.TxWithInfo, error) {
+	return utils.TxWithInfo{}, nil
+}
+
+func (t *testLane) SetAnteHandler(sdk.AnteHandler) {}
+
+func (t *testLane) Match(sdk.Context, sdk.Tx) bool {
+	return t.match
+}
+
+func (t *testLane) Contains(sdk.Tx) bool {
+	return t.contains
+}
+
+func (t *testLane) CountTx() int {
+	return t.count
+}
+
+func (t *testLane) Insert(context.Context, sdk.Tx) error {
+	if t.insertErr != nil {
+		return t.insertErr
+	}
+	t.count++
+	t.contains = true
+	return nil
+}
+
+func (t *testLane) Remove(sdk.Tx) error {
+	if t.removeErr != nil {
+		return t.removeErr
+	}
+	if t.count > 0 {
+		t.count--
+	}
+	t.contains = false
+	return nil
+}
+
+func (t *testLane) Select(context.Context, [][]byte) sdkmempool.Iterator {
+	return nil
+}
+
+func (t *testLane) Compare(sdk.Context, sdk.Tx, sdk.Tx) (int, error) {
+	return 0, nil
+}
+
+func (t *testLane) Priority(sdk.Context, sdk.Tx) any {
+	return 0
+}
+
+func (t *testLane) SignerExtractor() signerextraction.Adapter {
+	return t.signerExtractor
+}
+
+func TestLanedMempoolInsertReturnsSignerError(t *testing.T) {
+	lane := &testLane{
+		name:            "test",
+		match:           true,
+		signerExtractor: errorSignerAdapter{},
+	}
+
+	mempool, err := block.NewLanedMempool(
+		log.NewNopLogger(),
+		[]block.Lane{lane},
+	)
+	require.NoError(t, err)
+
+	err = mempool.Insert(context.Background(), EmptyTx{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to extract signers upon insertion")
+}
+
+func TestLanedMempoolRemoveReturnsSignerError(t *testing.T) {
+	lane := &testLane{
+		name:            "test",
+		contains:        true,
+		signerExtractor: errorSignerAdapter{},
+	}
+
+	mempool, err := block.NewLanedMempool(
+		log.NewNopLogger(),
+		[]block.Lane{lane},
+	)
+	require.NoError(t, err)
+
+	err = mempool.Remove(EmptyTx{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to extract signers upon removal")
+}

--- a/block/mempool_error_test.go
+++ b/block/mempool_error_test.go
@@ -24,6 +24,12 @@ func (errorSignerAdapter) GetSigners(sdk.Tx) ([]signerextraction.SignerData, err
 	return nil, fmt.Errorf("boom")
 }
 
+type emptySignerAdapter struct{}
+
+func (emptySignerAdapter) GetSigners(sdk.Tx) ([]signerextraction.SignerData, error) {
+	return []signerextraction.SignerData{}, nil
+}
+
 type testLane struct {
 	name            string
 	match           bool
@@ -147,4 +153,40 @@ func TestLanedMempoolRemoveReturnsSignerError(t *testing.T) {
 	err = mempool.Remove(EmptyTx{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to extract signers upon removal")
+}
+
+func TestLanedMempoolInsertRejectsEmptySigners(t *testing.T) {
+	lane := &testLane{
+		name:            "test",
+		match:           true,
+		signerExtractor: emptySignerAdapter{},
+	}
+
+	mempool, err := block.NewLanedMempool(
+		log.NewNopLogger(),
+		[]block.Lane{lane},
+	)
+	require.NoError(t, err)
+
+	err = mempool.Insert(context.Background(), EmptyTx{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no signers found for tx during insertion")
+}
+
+func TestLanedMempoolRemoveRejectsEmptySigners(t *testing.T) {
+	lane := &testLane{
+		name:            "test",
+		contains:        true,
+		signerExtractor: emptySignerAdapter{},
+	}
+
+	mempool, err := block.NewLanedMempool(
+		log.NewNopLogger(),
+		[]block.Lane{lane},
+	)
+	require.NoError(t, err)
+
+	err = mempool.Remove(EmptyTx{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no signers found for tx during removal")
 }

--- a/block/mempool_index.go
+++ b/block/mempool_index.go
@@ -31,6 +31,15 @@ func (idx *TxIndex) Insert(signer string, laneName string, lanePriority int, fir
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
+	if entries, ok := idx.index[signer]; ok {
+		for _, entry := range entries {
+			if entry.LaneName == laneName && entry.FirstSignerIdentifier == firstSignerIdentifier && entry.FirstSignerNonce == firstSignerNonce {
+				entry.LanePriority = lanePriority
+				return
+			}
+		}
+	}
+
 	entry := &LaneTxEntry{
 		LaneName:              laneName,
 		LanePriority:          lanePriority,
@@ -50,12 +59,14 @@ func (idx *TxIndex) Remove(signer string, laneName string, firstSignerIdentifier
 		return
 	}
 
-	for i, entry := range entries {
+	filtered := entries[:0]
+	for _, entry := range entries {
 		if entry.LaneName == laneName && entry.FirstSignerIdentifier == firstSignerIdentifier && entry.FirstSignerNonce == firstSignerNonce {
-			entries = append(entries[:i], entries[i+1:]...)
-			break
+			continue
 		}
+		filtered = append(filtered, entry)
 	}
+	entries = filtered
 
 	if len(entries) == 0 {
 		delete(idx.index, signer)

--- a/block/mempool_index_coverage_test.go
+++ b/block/mempool_index_coverage_test.go
@@ -1,0 +1,33 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxIndexDoesExistInLowerPriorityLane(t *testing.T) {
+	idx := NewTxIndex()
+	require.False(t, idx.DoesExistInLowerPriorityLane("signer1", 0))
+
+	idx.Insert("signer1", "lane-a", 1, "first-signer", 10)
+	require.False(t, idx.DoesExistInLowerPriorityLane("signer1", 2))
+	require.True(t, idx.DoesExistInLowerPriorityLane("signer1", 0))
+}
+
+func TestTxIndexRemoveMissingSignerNoop(t *testing.T) {
+	idx := NewTxIndex()
+	idx.Remove("missing", "lane-a", "first-signer", 10)
+
+	require.Empty(t, idx.index)
+}
+
+func TestTxIndexRemoveDeletesEmptySignerEntry(t *testing.T) {
+	idx := NewTxIndex()
+	idx.Insert("signer1", "lane-a", 1, "first-signer", 10)
+
+	idx.Remove("signer1", "lane-a", "first-signer", 10)
+
+	_, ok := idx.index["signer1"]
+	require.False(t, ok)
+}

--- a/block/mempool_index_test.go
+++ b/block/mempool_index_test.go
@@ -1,0 +1,49 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxIndexInsertDeduplicates(t *testing.T) {
+	idx := NewTxIndex()
+
+	idx.Insert("signer1", "lane-a", 2, "first-signer", 10)
+	idx.Insert("signer1", "lane-a", 3, "first-signer", 10)
+
+	entries := idx.index["signer1"]
+	require.Len(t, entries, 1)
+	require.Equal(t, 3, entries[0].LanePriority)
+}
+
+func TestTxIndexRemoveFiltersAllMatches(t *testing.T) {
+	idx := NewTxIndex()
+	idx.index["signer1"] = []*LaneTxEntry{
+		{
+			LaneName:              "lane-a",
+			LanePriority:          1,
+			FirstSignerIdentifier: "first-signer",
+			FirstSignerNonce:      10,
+		},
+		{
+			LaneName:              "lane-a",
+			LanePriority:          2,
+			FirstSignerIdentifier: "first-signer",
+			FirstSignerNonce:      10,
+		},
+		{
+			LaneName:              "lane-b",
+			LanePriority:          3,
+			FirstSignerIdentifier: "first-signer",
+			FirstSignerNonce:      11,
+		},
+	}
+
+	idx.Remove("signer1", "lane-a", "first-signer", 10)
+
+	entries := idx.index["signer1"]
+	require.Len(t, entries, 1)
+	require.Equal(t, "lane-b", entries[0].LaneName)
+	require.Equal(t, uint64(11), entries[0].FirstSignerNonce)
+}

--- a/block/mempool_test.go
+++ b/block/mempool_test.go
@@ -1,0 +1,106 @@
+package block_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	protov2 "google.golang.org/protobuf/proto"
+
+	"cosmossdk.io/log"
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	signerextraction "github.com/skip-mev/block-sdk/v2/adapters/signer_extraction_adapter"
+	"github.com/skip-mev/block-sdk/v2/block"
+	"github.com/skip-mev/block-sdk/v2/block/base"
+)
+
+func matchHandlerAlwaysTrue(ctx sdk.Context, tx sdk.Tx) bool {
+	return true
+}
+
+type EmptyTx struct{}
+
+func (e EmptyTx) GetMsgs() []sdk.Msg {
+	return []sdk.Msg{}
+}
+
+func (e EmptyTx) GetMsgsV2() ([]protov2.Message, error) {
+	return []protov2.Message{}, nil
+}
+
+func NoopEncoder(tx sdk.Tx) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func NoopDecoder(txBytes []byte) (sdk.Tx, error) {
+	return EmptyTx{}, nil
+}
+
+type NoopAdapter struct{}
+
+func (n NoopAdapter) GetSigners(tx sdk.Tx) ([]signerextraction.SignerData, error) {
+	return []signerextraction.SignerData{
+		{
+			Signer:   []byte("noop"),
+			Sequence: 0,
+		},
+	}, nil
+}
+
+// TestMempoolLaneWithMaxTxs tests that a laned mempool with a lane that has MaxTxs
+// set to 1 only allows one transaction to be inserted into that lane, but allows
+// additional transactions to be inserted into other lanes.
+func TestMempoolLaneWithMaxTxs(t *testing.T) {
+	priorityLane, err := base.NewBaseLane(
+		base.LaneConfig{
+			Logger:          log.NewNopLogger(),
+			TxEncoder:       NoopEncoder,
+			TxDecoder:       NoopDecoder,
+			SignerExtractor: NoopAdapter{},
+			MaxTxs:          1,
+			MaxBlockSpace:   sdkmath.LegacyMustNewDecFromStr("0.5"),
+		},
+		"priority",
+	)
+	require.NoError(t, err)
+	priorityLane = priorityLane.WithOptions(base.WithMatchHandler(
+		matchHandlerAlwaysTrue,
+	))
+
+	defaultLane, err := base.NewBaseLane(
+		base.LaneConfig{
+			Logger:          log.NewNopLogger(),
+			TxEncoder:       NoopEncoder,
+			TxDecoder:       NoopDecoder,
+			SignerExtractor: NoopAdapter{},
+			MaxTxs:          0,
+			MaxBlockSpace:   sdkmath.LegacyNewDec(0),
+		},
+		"default",
+	)
+	require.NoError(t, err)
+	defaultLane = defaultLane.WithOptions(base.WithMatchHandler(
+		matchHandlerAlwaysTrue,
+	))
+
+	mempool, err := block.NewLanedMempool(
+		log.NewNopLogger(),
+		[]block.Lane{
+			priorityLane,
+			defaultLane,
+		},
+	)
+	require.NoError(t, err)
+
+	ctx := sdk.Context{}
+
+	err = mempool.Insert(ctx, EmptyTx{})
+	require.NoError(t, err)
+
+	err = mempool.Insert(ctx, EmptyTx{})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, mempool.CountTx())
+}


### PR DESCRIPTION
When a transaction exceeds the max count of a lane, it is passed down to the next lane instead of being completely rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mempool behavior: transactions now trickle between lanes on capacity/priority and avoid being skipped; index deduplicates entries and now removes all matching signer entries when appropriate.
  * Clearer error handling: insertion/removal now return explicit errors when signer extraction fails or yields no signers.

* **Tests**
  * Added extensive tests covering lane capacity/priority behavior, signer-extraction error cases, index deduplication, and removal semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->