### PR TITLE
[C-696] fix(mempool_lanes): capacity error propagation

### DIFF
--- a/block/mempool.go
+++ b/block/mempool.go
@@ -96,6 +96,7 @@ func (m *LanedMempool) Insert(ctx context.Context, tx sdk.Tx) (err error) {
 	}()
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	var capacityErr error
 
 laneMatching:
 	for index, lane := range m.registry {
@@ -123,6 +124,7 @@ laneMatching:
 				if errors.Is(err, sdkmempool.ErrMempoolTxMaxCapacity) {
 					// if the lane is at capacity, we let it trickle down to the
 					// next lane.
+					capacityErr = err
 					continue laneMatching
 				}
 				return err
@@ -140,6 +142,9 @@ laneMatching:
 		}
 	}
 
+	if capacityErr != nil {
+		return capacityErr
+	}
 	return nil
 }
 

--- a/block/mempool_coverage_test.go
+++ b/block/mempool_coverage_test.go
@@ -50,6 +50,26 @@ func TestLanedMempoolInsertTricklesOnCapacity(t *testing.T) {
 	require.Equal(t, 1, defaultLane.CountTx())
 }
 
+func TestLanedMempoolInsertReturnsCapacityErrorWhenNoLaneAccepts(t *testing.T) {
+	signer := signerextraction.SignerData{Signer: sdk.AccAddress("addr1"), Sequence: 1}
+	adapter := staticSignerAdapter{signers: []signerextraction.SignerData{signer}}
+
+	priorityLane := &testLane{
+		name:            "priority",
+		match:           true,
+		insertErr:       sdkmempool.ErrMempoolTxMaxCapacity,
+		signerExtractor: adapter,
+		maxBlockSpace:   math.LegacyOneDec(),
+	}
+
+	mempool, err := block.NewLanedMempool(log.NewNopLogger(), []block.Lane{priorityLane})
+	require.NoError(t, err)
+
+	err = mempool.Insert(sdk.WrapSDKContext(sdk.Context{}), EmptyTx{})
+	require.ErrorIs(t, err, sdkmempool.ErrMempoolTxMaxCapacity)
+	require.Equal(t, 0, priorityLane.CountTx())
+}
+
 func TestLanedMempoolInsertSkipsHigherLaneWhenLowerExists(t *testing.T) {
 	signer := signerextraction.SignerData{Signer: sdk.AccAddress("addr1"), Sequence: 1}
 	adapter := staticSignerAdapter{signers: []signerextraction.SignerData{signer}}


### PR DESCRIPTION
Review after https://github.com/InjectiveLabs/block-sdk/pull/8 was merged:

• The mempool now swallows `ErrMempoolTxMaxCapacity` when no lower-priority lane accepts the transaction, returning success despite not inserting it.

  Review comment:

  **- [P1]** Return capacity error when no lower lane accepts tx — `block/mempool.go:121-126`
    When lane.Insert returns ErrMempoolTxMaxCapacity, the code always continues to the next lane. If there are no subsequent lanes that match the tx (e.g., only one lane, or
    remaining lanes’ Match returns false), the function falls through and returns nil, even though the tx was never inserted. Callers will treat the tx as accepted and it
    will be dropped; consider returning the capacity error when no later lane inserts the tx (e.g., track whether insertion succeeded or propagate the last capacity error on
    fallthrough).

    
## This PR

If the issue described above is important to us, I believe it is - we don't want txns to be dropped from mempool because of that. They have to stay in mempool and be retried to insert when capacity of lanes is available again (e.g. next block)...

@arrivets @gorgos please validate this path and fix attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mempool transaction insertion now gracefully attempts multiple lanes when capacity is reached, only returning an error if all lanes are full.

* **Tests**
  * Added test coverage for mempool capacity scenarios where all lanes reject transactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->